### PR TITLE
CoreRedesign

### DIFF
--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -2,12 +2,13 @@ services:
 
   test:
     image: golang:1.15-alpine
-    command: "make test"
+    container_name: casty.test
+    command: "go test -v ./tests -race"
     working_dir: /work
     volumes:
       - ../:/work
     networks:
-      - casty-test
+      - casty
 
   redis:
     image: redis:alpine
@@ -18,7 +19,7 @@ services:
     environment:
       - REDIS_REPLICATION_MODE=master
     networks:
-      - casty-test
+      - casty
 
   db:
     image: mongo:latest
@@ -30,8 +31,8 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: "super-secure-mongodb-password"
       MONGO_INITDB_DATABASE: casty
     networks:
-      - casty-test
+      - casty
 
 networks:
-  casty-test:
+  casty:
     driver: bridge

--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
 
   test:
-    image: golang:1.15-alpine
+    image: golang:1.15
     container_name: casty.test
     command: "go test -v ./tests -race"
     working_dir: /work

--- a/.ci/docker-compose.yaml
+++ b/.ci/docker-compose.yaml
@@ -1,0 +1,37 @@
+services:
+
+  test:
+    image: golang:1.15-alpine
+    command: "make test"
+    working_dir: /work
+    volumes:
+      - ../:/work
+    networks:
+      - casty-test
+
+  redis:
+    image: redis:alpine
+    container_name: casty.redis
+    command: redis-server --requirepass 'super-secure-redis-password'
+    ports:
+      - 6379
+    environment:
+      - REDIS_REPLICATION_MODE=master
+    networks:
+      - casty-test
+
+  db:
+    image: mongo:latest
+    container_name: casty.db
+    ports:
+      - 27017
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: gotest
+      MONGO_INITDB_ROOT_PASSWORD: "super-secure-mongodb-password"
+      MONGO_INITDB_DATABASE: casty
+    networks:
+      - casty-test
+
+networks:
+  casty-test:
+    driver: bridge

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,10 +15,17 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       DOCKER_TARGET_PLATFORM: linux/amd64,linux/arm64,linux/arm/v7
+      COMPOSE_FILE: .ci/docker-compose.yaml
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
-            
+           
+      - name: Run redis and mongodb containers
+        run: docker-compose up -d redis db
+
+      - name: Run tests
+        run: docker-compose run test
+
       - name: Set up Docker Buildx
         uses: crazy-max/ghaction-docker-buildx@v2
         with:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,39 +7,42 @@ on:
       - v*
 jobs:
   push_to_registries:
-    name: Push Docker image to Dockerhub and Github
+    name: Push Docker image to Dockerhub
     runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: docker.io
+      DOCKER_IMAGE: castyapp/grpc
+      DOCKER_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKER_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKER_TARGET_PLATFORM: linux/amd64,linux/arm64,linux/arm/v7
     steps:
       - name: Check out the repo
         uses: actions/checkout@v2
+            
+      - name: Set up Docker Buildx
+        uses: crazy-max/ghaction-docker-buildx@v2
+        with:
+          version: latest
 
-      - name: Declare git repo vars
-        id: vars
-        shell: bash
+      - name: Prepare
+        if: success()
+        id: prepare
         run: |
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-
-      - uses: docker/setup-buildx-action@v1
+          echo ::set-output name=docker_platform::${DOCKER_TARGET_PLATFORM}
+          echo ::set-output name=docker_image::${DOCKER_REGISTRY}/${DOCKER_IMAGE}
+          echo ::set-output name=release_version::${GITHUB_REF#refs/*/}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          logout: true
+        if: success()
+        run: |
+          echo "${DOCKER_TOKEN}" | docker login ${DOCKER_REGISTRY} --username "${DOCKER_USERNAME}" --password-stdin
 
-      - name: Build and Push to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile
-          tags: castylab/grpc:latest
-          push: true
-
-      - name: Build and Push alpine version to Docker Hub
-        uses: docker/build-push-action@v2
-        with:
-          context: .
-          file: ./Dockerfile-alpine
-          tags: castylab/grpc:alpine
-          push: true
+      - name: Run Buildx (push image)
+        if: success()
+        run: |
+          docker buildx build \
+          --platform ${{ steps.prepare.outputs.docker_platform }} \
+          --tag ${{ steps.prepare.outputs.docker_image }}:latest \
+          --tag ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.release_version }} \
+          --file ./Dockerfile \
+          --output type=image,push=true .

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -9,7 +9,7 @@ jobs:
     name: Run test suite
     runs-on: ubuntu-latest
     env:
-      COMPOSE_FILE: .ci/docker-compose.yml
+      COMPOSE_FILE: .ci/docker-compose.yaml
 
     steps:
     - name: Checkout code

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -15,9 +15,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
-    - name: Build docker images
-      run: docker-compose build
-
     - name: Run redis and mongodb containers
       run: docker-compose up -d redis db
 

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -18,5 +18,8 @@ jobs:
     - name: Build docker images
       run: docker-compose build
 
+    - name: Run redis and mongodb containers
+      run: docker-compose up -d redis db
+
     - name: Run tests
       run: docker-compose run test

--- a/.github/workflows/docker-test.yaml
+++ b/.github/workflows/docker-test.yaml
@@ -1,0 +1,22 @@
+name: Test
+on:
+  push:
+    branches:
+      - "*"
+
+jobs:
+  test:
+    name: Run test suite
+    runs-on: ubuntu-latest
+    env:
+      COMPOSE_FILE: .ci/docker-compose.yml
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build docker images
+      run: docker-compose build
+
+    - name: Run tests
+      run: docker-compose run test

--- a/config/config.go
+++ b/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"fmt"
 	"io/ioutil"
 
+	"github.com/castyapp/grpc.server/core"
 	"github.com/hashicorp/hcl"
 )
 
@@ -11,7 +13,6 @@ type ConfigMap struct {
 	Env       string          `hcl:"env"`
 	Metrics   bool            `hcl:"metrics"`
 	Timezone  string          `hcl:"timezone"`
-	Listener  GrpcListener    `hcl:"listener,block"`
 	Redis     RedisConfig     `hcl:"redis,block"`
 	DB        DBConfig        `hcl:"db,block"`
 	Oauth     OauthConfig     `hcl:"oauth,block"`
@@ -19,11 +20,6 @@ type ConfigMap struct {
 	Sentry    SentryConfig    `hcl:"sentry,block"`
 	JWT       JWTConfig       `hcl:"jwt,block"`
 	Recaptcha RecaptchaConfig `hcl:"recaptcha,block"`
-}
-
-type GrpcListener struct {
-	Host string `hcl:"host"`
-	Port int    `hcl:"port"`
 }
 
 type RedisConfig struct {
@@ -108,4 +104,14 @@ func LoadFile(filename string) (c *ConfigMap, err error) {
 	}
 
 	return
+}
+
+func Provider(ctx *core.Context) error {
+	configFilePath := ctx.MustGetString("config.filepath")
+	configMap, err := LoadFile(configFilePath)
+	if err != nil {
+		return fmt.Errorf("could not load config: %v", err)
+	}
+	ctx.Set("config.map", configMap)
+	return nil
 }

--- a/core/context.go
+++ b/core/context.go
@@ -1,0 +1,120 @@
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"reflect"
+	"sync"
+	"time"
+)
+
+var (
+	ErrKeyNodFound = errors.New("key not found!")
+)
+
+type Context struct {
+	ctx          context.Context
+	items        map[string]interface{}
+	sync.RWMutex // Read Write mutex, guards access to internal map.
+}
+
+func NewContext(ctx context.Context) *Context {
+	return &Context{ctx: ctx, items: make(map[string]interface{}, 0)}
+}
+
+func (c *Context) With(handlers ...func(ctx *Context) error) *Context {
+	for _, handler := range handlers {
+		if err := handler(c); err != nil {
+			fmt.Printf("Could not register provider [%s] cause [%v]\n", reflect.ValueOf(handler).Kind().String(), err)
+			os.Exit(1)
+		}
+	}
+	return c
+}
+
+func (c *Context) MustGet(key string) (value interface{}) {
+	value, err := c.Get(key)
+	if err != nil {
+		log.Panicln(err)
+	}
+	return value
+}
+
+func (c *Context) MustGetBoolean(key string) bool {
+	value, err := c.Get(key)
+	if err != nil {
+		log.Panicln(err)
+	}
+	return value.(bool)
+}
+
+func (c *Context) GetBoolean(key string) (bool, error) {
+	value, err := c.Get(key)
+	if err != nil {
+		return false, err
+	}
+	return value.(bool), nil
+}
+
+func (c *Context) GetString(key string) (string, error) {
+	value, err := c.Get(key)
+	if err != nil {
+		return "", err
+	}
+	return value.(string), nil
+}
+
+func (c *Context) MustGetString(key string) string {
+	value, err := c.Get(key)
+	if err != nil {
+		log.Panicln(err)
+	}
+	return value.(string)
+}
+
+func (c *Context) Count() int {
+	count := 0
+	c.RLock()
+	count += len(c.items)
+	c.RUnlock()
+	return count
+}
+
+func (c *Context) Get(key string) (interface{}, error) {
+	c.RLock()
+	val, ok := c.items[key]
+	if !ok {
+		return nil, ErrKeyNodFound
+	}
+	c.RUnlock()
+	return val, nil
+}
+
+func (c *Context) Set(key string, value interface{}) error {
+	c.Lock()
+	if _, ok := c.items[key]; ok {
+		return fmt.Errorf(fmt.Sprintf("Key [%s] already exists!", key))
+	}
+	c.items[key] = value
+	c.Unlock()
+	return nil
+}
+
+func (c *Context) Deadline() (deadline time.Time, ok bool) {
+	return c.ctx.Deadline()
+}
+
+func (c *Context) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+func (c *Context) Err() error {
+	return c.ctx.Err()
+}
+
+func (c *Context) Value(key interface{}) interface{} {
+	return c.ctx.Value(key)
+}

--- a/db/init.go
+++ b/db/init.go
@@ -6,31 +6,35 @@ import (
 	"time"
 
 	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
-func Configure(c *config.ConfigMap) (*mongo.Database, error) {
+func Provider(ctx *core.Context) error {
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	mCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
+	cm := ctx.MustGet("config.map").(*config.ConfigMap)
+
 	opts := options.Client()
-	opts.ApplyURI(fmt.Sprintf("mongodb://%s:%d", c.DB.Host, c.DB.Port))
+	opts.ApplyURI(fmt.Sprintf("mongodb://%s:%d", cm.DB.Host, cm.DB.Port))
 	opts.SetAuth(options.Credential{
-		Username:   c.DB.User,
-		Password:   c.DB.Pass,
-		AuthSource: c.DB.Name,
+		Username: cm.DB.User,
+		Password: cm.DB.Pass,
+		//AuthSource: cm.DB.Name,
 	})
 
 	client, err := mongo.NewClient(opts)
 	if err != nil {
-		return nil, fmt.Errorf("could not create new mongodb client: %v", err)
+		return fmt.Errorf("could not create new mongodb client: %v", err)
 	}
 
-	if err := client.Connect(ctx); err != nil {
-		return nil, fmt.Errorf("could not connect to mongodb client: %v", err)
+	if err := client.Connect(mCtx); err != nil {
+		return fmt.Errorf("could not connect to mongodb client: %v", err)
 	}
 
-	return client.Database(c.DB.Name), nil
+	connection := client.Database(cm.DB.Name)
+	return ctx.Set("db.mongo", connection)
 }

--- a/example.config.hcl
+++ b/example.config.hcl
@@ -10,12 +10,6 @@ env = "dev"
 # Timezone
 timezone = "America/California"
 
-# gRPC TCP listener config
-listener {
-  host = "0.0.0.0"
-  port = 8000
-}
-
 # Redis configurations
 redis {
   # if you wish to use redis cluster, set this value to true

--- a/go.mod
+++ b/go.mod
@@ -12,9 +12,10 @@ require (
 	github.com/hashicorp/hcl v1.0.0
 	github.com/minio/minio-go v6.0.14+incompatible
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 	go.mongodb.org/mongo-driver v1.5.0
 	golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2
 	golang.org/x/oauth2 v0.0.0-20210323180902-22b0adad7558
-	google.golang.org/genproto v0.0.0-20210324141432-3032e8ff099e
-	google.golang.org/grpc v1.36.0
+	google.golang.org/genproto v0.0.0-20210325224202-eed09b1b5210
+	google.golang.org/grpc v1.36.1
 )

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8Nz
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v1.0.2 h1:KPldsxuKGsS2FPWsNeg9ZO18aCrGKujPoWXn2yo+KQM=
@@ -275,6 +276,7 @@ github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -304,6 +306,7 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
@@ -605,8 +608,8 @@ google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7Fc
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20210324141432-3032e8ff099e h1:IYrHTUywwtorLXynts01yby09nLqYNNnnveUnnLzaYA=
-google.golang.org/genproto v0.0.0-20210324141432-3032e8ff099e/go.mod h1:f2Bd7+2PlaVKmvKQ52aspJZXIDaRQBVdOOBfJ5i8OEs=
+google.golang.org/genproto v0.0.0-20210325224202-eed09b1b5210 h1:fFxjezD+ZiiYJ6zyfH738tgcWOqfzWl9I1GoepZzrI4=
+google.golang.org/genproto v0.0.0-20210325224202-eed09b1b5210/go.mod h1:f2Bd7+2PlaVKmvKQ52aspJZXIDaRQBVdOOBfJ5i8OEs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -620,8 +623,9 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.34.0/go.mod h1:WotjhfgOW/POjDeRt8vscBtXq+2VjORFy659qA51WJ8=
-google.golang.org/grpc v1.36.0 h1:o1bcQ6imQMIOpdrO3SWf2z5RV72WbDwdXuK0MDlc8As=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
+google.golang.org/grpc v1.36.1 h1:cmUfbeGKnz9+2DD/UYsMQXeqbHZqZDs4eQwW0sFOpBY=
+google.golang.org/grpc v1.36.1/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -649,6 +653,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20191120175047-4206685974f2/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/providers/config.go
+++ b/providers/config.go
@@ -1,0 +1,24 @@
+package providers
+
+import (
+	"fmt"
+
+	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
+)
+
+type ConfigProvider struct{}
+
+func (p *ConfigProvider) Register(ctx *core.Context) error {
+	configFilePath := ctx.MustGetString("config.filepath")
+	configMap, err := config.LoadFile(configFilePath)
+	if err != nil {
+		return fmt.Errorf("could not load config: %v", err)
+	}
+	ctx.Set("config.map", configMap)
+	return nil
+}
+
+func (p *ConfigProvider) Close(ctx *core.Context) error {
+	return nil
+}

--- a/providers/database.go
+++ b/providers/database.go
@@ -1,0 +1,48 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+)
+
+type DatabaseProvider struct {
+	client *mongo.Client
+}
+
+func (p *DatabaseProvider) Register(ctx *core.Context) error {
+	mCtx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+
+	cm := ctx.MustGet("config.map").(*config.ConfigMap)
+
+	opts := options.Client()
+	opts.ApplyURI(fmt.Sprintf("mongodb://%s:%d", cm.DB.Host, cm.DB.Port))
+	opts.SetAuth(options.Credential{
+		Username: cm.DB.User,
+		Password: cm.DB.Pass,
+		//AuthSource: cm.DB.Name,
+	})
+
+	client, err := mongo.NewClient(opts)
+	if err != nil {
+		return fmt.Errorf("could not create new mongodb client: %v", err)
+	}
+	p.client = client
+
+	if err := client.Connect(mCtx); err != nil {
+		return fmt.Errorf("could not connect to mongodb client: %v", err)
+	}
+
+	conn := client.Database(cm.DB.Name)
+	return ctx.Set("db.mongo", conn)
+}
+
+func (p *DatabaseProvider) Close(ctx *core.Context) error {
+	return p.client.Disconnect(ctx)
+}

--- a/providers/lambda.go
+++ b/providers/lambda.go
@@ -1,0 +1,22 @@
+package providers
+
+import "github.com/castyapp/grpc.server/core"
+
+type LambdaProvider struct {
+	Registeration func(ctx *core.Context) error
+	Closing       func(ctx *core.Context) error
+}
+
+func (p *LambdaProvider) Register(ctx *core.Context) error {
+	if p.Registeration != nil {
+		return p.Registeration(ctx)
+	}
+	return nil
+}
+
+func (p *LambdaProvider) Close(ctx *core.Context) error {
+	if p.Closing != nil {
+		return p.Closing(ctx)
+	}
+	return nil
+}

--- a/providers/redis.go
+++ b/providers/redis.go
@@ -1,0 +1,49 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
+	"github.com/go-redis/redis/v8"
+)
+
+type RedisProvider struct {
+	client *redis.Client
+}
+
+func (p *RedisProvider) Register(ctx *core.Context) error {
+	cm := ctx.MustGet("config.map").(*config.ConfigMap)
+	if cm.Redis.Cluster {
+		p.client = redis.NewFailoverClient(&redis.FailoverOptions{
+			SentinelAddrs:    cm.Redis.Sentinels,
+			SentinelPassword: cm.Redis.SentinelPass,
+			Password:         cm.Redis.Pass,
+			MasterName:       cm.Redis.MasterName,
+			DB:               0,
+		})
+	} else {
+		p.client = redis.NewClient(&redis.Options{
+			Addr:     cm.Redis.Addr,
+			Password: cm.Redis.Pass,
+		})
+	}
+
+	cmd := p.client.Ping(context.Background())
+	if res := cmd.Val(); res != "PONG" {
+		if cm.Redis.Cluster {
+			log.Println(fmt.Sprintf("Redis: SentinelAddrs [%s]", cm.Redis.Sentinels))
+		} else {
+			log.Println(fmt.Sprintf("Redis: Addr [%s]", cm.Redis.Addr))
+		}
+		return fmt.Errorf("could not ping the redis server: %v", cmd.Err())
+	}
+
+	return ctx.Set("redis.conn", p.client)
+}
+
+func (p *RedisProvider) Close(ctx *core.Context) error {
+	return p.client.Close()
+}

--- a/providers/sentry.go
+++ b/providers/sentry.go
@@ -1,0 +1,27 @@
+package providers
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
+	"github.com/getsentry/sentry-go"
+)
+
+type SentryProvider struct{}
+
+func (p *SentryProvider) Register(ctx *core.Context) error {
+	cm := ctx.MustGet("config.map").(*config.ConfigMap)
+	if cm.Sentry.Enabled {
+		if err := sentry.Init(sentry.ClientOptions{Dsn: cm.Sentry.Dsn}); err != nil {
+			return fmt.Errorf("could not initilize sentry: %v", err)
+		}
+	}
+	return nil
+}
+
+func (p *SentryProvider) Close(ctx *core.Context) error {
+	sentry.Flush(5 * time.Second)
+	return nil
+}

--- a/server.go
+++ b/server.go
@@ -6,15 +6,13 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"time"
 
 	"github.com/CastyLab/grpc.proto/proto"
 	"github.com/castyapp/grpc.server/config"
 	"github.com/castyapp/grpc.server/core"
-	"github.com/castyapp/grpc.server/db"
 	"github.com/castyapp/grpc.server/jwt"
 	"github.com/castyapp/grpc.server/oauth"
-	"github.com/castyapp/grpc.server/redis"
+	"github.com/castyapp/grpc.server/providers"
 	"github.com/castyapp/grpc.server/services/auth"
 	"github.com/castyapp/grpc.server/services/message"
 	"github.com/castyapp/grpc.server/services/theater"
@@ -45,64 +43,60 @@ func init() {
 
 	ctx = core.NewContext(context.Background())
 	ctx.Set("config.filepath", *configFileName)
+
 	ctx.With(
 
 		// Registering configmap provider
-		config.Provider,
+		&providers.ConfigProvider{},
 
 		// Init sentry loggin if its enabled
-		func(ctx *core.Context) error {
-			cm := ctx.MustGet("config.map").(*config.ConfigMap)
-			if cm.Sentry.Enabled {
-				if err := sentry.Init(sentry.ClientOptions{Dsn: cm.Sentry.Dsn}); err != nil {
-					return fmt.Errorf("could not initilize sentry: %v", err)
-				}
-			}
-			return nil
-		},
+		&providers.SentryProvider{},
 
 		// config database (mongodb)
-		db.Provider,
+		&providers.DatabaseProvider{},
+
+		// config redis connection
+		&providers.RedisProvider{},
 
 		// configure jwt
-		func(ctx *core.Context) error {
-			cm := ctx.MustGet("config.map").(*config.ConfigMap)
-			if err := jwt.Load(cm); err != nil {
-				return fmt.Errorf("could not load jwt configuration: %v", err)
-			}
-			return nil
+		&providers.LambdaProvider{
+			Registeration: func(ctx *core.Context) error {
+				cm := ctx.MustGet("config.map").(*config.ConfigMap)
+				if err := jwt.Load(cm); err != nil {
+					return fmt.Errorf("could not load jwt configuration: %v", err)
+				}
+				return nil
+			},
 		},
 
 		// configure oauth clients
-		func(ctx *core.Context) error {
-			cm := ctx.MustGet("config.map").(*config.ConfigMap)
-			if err := oauth.ConfigureOAUTHClients(cm); err != nil {
-				return fmt.Errorf("could not load oauth clients configurations: %v", err)
-			}
-			return nil
+		&providers.LambdaProvider{
+			Registeration: func(ctx *core.Context) error {
+				cm := ctx.MustGet("config.map").(*config.ConfigMap)
+				if err := oauth.ConfigureOAUTHClients(cm); err != nil {
+					return fmt.Errorf("could not load oauth clients configurations: %v", err)
+				}
+				return nil
+			},
 		},
 
 		// configure s3 bucket (minio) storage
-		func(ctx *core.Context) error {
-			cm := ctx.MustGet("config.map").(*config.ConfigMap)
-			if err := storage.Configure(cm); err != nil {
-				return fmt.Errorf("could not configure s3 bucket storage client: %v", err)
-			}
-			return nil
+		&providers.LambdaProvider{
+			Registeration: func(ctx *core.Context) error {
+				cm := ctx.MustGet("config.map").(*config.ConfigMap)
+				if err := storage.Configure(cm); err != nil {
+					return fmt.Errorf("could not configure s3 bucket storage client: %v", err)
+				}
+				return nil
+			},
 		},
-		redis.Provider,
 	)
 
 }
 
 func main() {
 
-	defer func() {
-
-		// Since sentry emits events in the background we need to make sure
-		// they are sent before we shut down
-		sentry.Flush(time.Second * 5)
-	}()
+	defer ctx.Close()
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", *host, *port))
 	if err != nil {

--- a/services/auth/authenticate.go
+++ b/services/auth/authenticate.go
@@ -4,14 +4,14 @@ import (
 	"strings"
 
 	"github.com/CastyLab/grpc.proto/proto"
+	"github.com/castyapp/grpc.server/core"
 	"github.com/castyapp/grpc.server/db/models"
 	"github.com/castyapp/grpc.server/jwt"
-	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
-func Authenticate(db *mongo.Database, req *proto.AuthenticateRequest) (user *models.User, err error) {
+func Authenticate(ctx *core.Context, req *proto.AuthenticateRequest) (user *models.User, err error) {
 
 	if req == nil || req.Token == nil {
 		return nil, status.Error(codes.InvalidArgument, "Token is required!")
@@ -19,7 +19,7 @@ func Authenticate(db *mongo.Database, req *proto.AuthenticateRequest) (user *mod
 
 	stringToken := strings.ReplaceAll(string(req.Token), "Bearer ", "")
 
-	user, err = jwt.DecodeAuthToken(db, []byte(stringToken))
+	user, err = jwt.DecodeAuthToken(ctx, []byte(stringToken))
 	if err != nil {
 		return nil, status.Error(codes.Unauthenticated, "Unauthorized!")
 	}

--- a/services/auth/refresh.go
+++ b/services/auth/refresh.go
@@ -8,15 +8,23 @@ import (
 	"github.com/castyapp/grpc.server/jwt"
 	"github.com/getsentry/sentry-go"
 	"github.com/pkg/errors"
+	"go.mongodb.org/mongo-driver/mongo"
 )
 
 func (s *Service) RefreshToken(ctx context.Context, req *proto.RefreshTokenRequest) (*proto.AuthResponse, error) {
+
+	db, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
+	db = db.(*mongo.Database)
 
 	if req.RefreshedToken == nil {
 		return nil, errors.New("Refreshed token is required!")
 	}
 
-	newAuthToken, newRefreshedToken, err := jwt.RefreshToken(s.db, ctx, string(req.RefreshedToken))
+	newAuthToken, newRefreshedToken, err := jwt.RefreshToken(s.Context, string(req.RefreshedToken))
 	if err != nil {
 		sentry.CaptureException(err)
 		return nil, errors.New("Could not create tokens, please try again later!")

--- a/services/auth/service.go
+++ b/services/auth/service.go
@@ -2,12 +2,11 @@ package auth
 
 import (
 	"context"
-	"log"
 	"net/http"
 	"regexp"
 
 	"github.com/CastyLab/grpc.proto/proto"
-	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
 	"github.com/castyapp/grpc.server/db/models"
 	"github.com/castyapp/grpc.server/jwt"
 	"github.com/getsentry/sentry-go"
@@ -19,33 +18,21 @@ import (
 )
 
 type Service struct {
-	c  *config.ConfigMap
-	db *mongo.Database
+	*core.Context
 	proto.UnimplementedAuthServiceServer
 }
 
-func NewService(ctx context.Context) *Service {
-	database := ctx.Value("db")
-	if database == nil {
-		log.Panicln("db value is required in context!")
-	}
-	configMap := ctx.Value("cm")
-	if configMap == nil {
-		log.Panicln("configMap value is required in context!")
-	}
-	return &Service{db: database.(*mongo.Database), c: configMap.(*config.ConfigMap)}
+func NewService(ctx *core.Context) *Service {
+	return &Service{Context: ctx}
 }
 
 func (s *Service) isEmail(user string) bool {
-
 	re := regexp.MustCompile(
 		"^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])" +
 			"?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
-
 	if re.MatchString(user) {
 		return true
 	}
-
 	return false
 }
 
@@ -57,7 +44,8 @@ func ValidatePassword(user *models.User, pass string) bool {
 func (s *Service) Authenticate(ctx context.Context, req *proto.AuthRequest) (*proto.AuthResponse, error) {
 
 	var (
-		collection   = s.db.Collection("users")
+		db           = s.MustGet("db.mongo").(*mongo.Database)
+		collection   = db.Collection("users")
 		user         = new(models.User)
 		unauthorized = status.Error(codes.Unauthenticated, "Unauthorized!")
 	)
@@ -77,7 +65,7 @@ func (s *Service) Authenticate(ctx context.Context, req *proto.AuthRequest) (*pr
 
 	if ValidatePassword(user, req.Pass) {
 
-		token, refreshedToken, err := jwt.CreateNewTokens(s.db, ctx, user.ID.Hex())
+		token, refreshedToken, err := jwt.CreateNewTokens(s.Context, user.ID.Hex())
 		if err != nil {
 			sentry.CaptureException(err)
 			return nil, status.Error(codes.Internal, "Could not create auth token, Please try again later!")

--- a/services/theater/get.go
+++ b/services/theater/get.go
@@ -11,24 +11,30 @@ import (
 	"github.com/castyapp/grpc.server/services/auth"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Service) GetTheater(ctx context.Context, req *proto.GetTheaterRequest) (*proto.UserTheaterResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
-		err             error
+		db              = dbConn.(*mongo.Database)
 		authenticated   = false
 		authUser        = new(models.User)
 		dbTheater       = new(models.Theater)
-		usersCollection = s.db.Collection("users")
-		collection      = s.db.Collection("theaters")
+		usersCollection = db.Collection("users")
+		collection      = db.Collection("theaters")
 		failedResponse  = status.Error(codes.Internal, "Could not get theater, Please try again later!")
 	)
 
 	if req.AuthRequest != nil {
-		authUser, err = auth.Authenticate(s.db, req.AuthRequest)
+		authUser, err = auth.Authenticate(s.Context, req.AuthRequest)
 		if err != nil {
 			return nil, err
 		}
@@ -71,7 +77,7 @@ func (s *Service) GetTheater(ctx context.Context, req *proto.GetTheaterRequest) 
 		}
 	}
 
-	theater, err := helpers.NewTheaterProto(s.db, ctx, dbTheater)
+	theater, err := helpers.NewTheaterProto(db, ctx, dbTheater)
 	if err != nil {
 		log.Println(err)
 		return nil, failedResponse
@@ -81,7 +87,7 @@ func (s *Service) GetTheater(ctx context.Context, req *proto.GetTheaterRequest) 
 
 	if req.AuthRequest != nil {
 		findFilter := bson.M{"theater_id": dbTheater.ID, "user_id": authUser.ID}
-		countResult, err := s.db.Collection("follows").CountDocuments(ctx, findFilter)
+		countResult, err := db.Collection("follows").CountDocuments(ctx, findFilter)
 		if err == nil && countResult != 0 {
 			theater.Followed = true
 		}

--- a/services/theater/service.go
+++ b/services/theater/service.go
@@ -1,28 +1,15 @@
 package theater
 
 import (
-	"context"
-	"log"
-
 	"github.com/CastyLab/grpc.proto/proto"
-	"github.com/castyapp/grpc.server/config"
-	"go.mongodb.org/mongo-driver/mongo"
+	"github.com/castyapp/grpc.server/core"
 )
 
 type Service struct {
-	c  *config.ConfigMap
-	db *mongo.Database
+	*core.Context
 	proto.UnimplementedTheaterServiceServer
 }
 
-func NewService(ctx context.Context) *Service {
-	database := ctx.Value("db")
-	if database == nil {
-		log.Panicln("db value is required in context!")
-	}
-	configMap := ctx.Value("cm")
-	if configMap == nil {
-		log.Panicln("configMap value is required in context!")
-	}
-	return &Service{db: database.(*mongo.Database), c: configMap.(*config.ConfigMap)}
+func NewService(ctx *core.Context) *Service {
+	return &Service{Context: ctx}
 }

--- a/services/user/connections.go
+++ b/services/user/connections.go
@@ -20,12 +20,18 @@ import (
 
 func (s *Service) UpdateConnection(ctx context.Context, req *proto.ConnectionRequest) (*proto.ConnectionsResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db         = dbConn.(*mongo.Database)
 		connection = new(models.Connection)
-		collection = s.db.Collection("connections")
+		collection = db.Collection("connections")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -78,12 +84,18 @@ func (s *Service) UpdateConnection(ctx context.Context, req *proto.ConnectionReq
 
 func (s *Service) GetConnection(ctx context.Context, req *proto.ConnectionRequest) (*proto.ConnectionsResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db         = dbConn.(*mongo.Database)
 		connection = new(models.Connection)
-		collection = s.db.Collection("connections")
+		collection = db.Collection("connections")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -109,12 +121,18 @@ func (s *Service) GetConnection(ctx context.Context, req *proto.ConnectionReques
 
 func (s *Service) GetConnections(ctx context.Context, req *proto.AuthenticateRequest) (*proto.ConnectionsResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db          = dbConn.(*mongo.Database)
 		connections = make([]*proto.Connection, 0)
-		collection  = s.db.Collection("connections")
+		collection  = db.Collection("connections")
 	)
 
-	user, err := auth.Authenticate(s.db, req)
+	user, err := auth.Authenticate(s.Context, req)
 	if err != nil {
 		return nil, err
 	}

--- a/services/user/friend.go
+++ b/services/user/friend.go
@@ -10,20 +10,27 @@ import (
 	"github.com/castyapp/grpc.server/services/auth"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Service) GetFriend(ctx context.Context, req *proto.FriendRequest) (*proto.FriendResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db                 = dbConn.(*mongo.Database)
 		dbFriend           = new(models.Friend)
 		dbFriendUserObject = new(models.User)
-		userCollection     = s.db.Collection("users")
-		friendsCollection  = s.db.Collection("friends")
+		userCollection     = db.Collection("users")
+		friendsCollection  = db.Collection("friends")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -66,14 +73,20 @@ func (s *Service) GetFriend(ctx context.Context, req *proto.FriendRequest) (*pro
 
 func (s *Service) GetFriendRequest(ctx context.Context, req *proto.FriendRequest) (*proto.Friend, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db                = dbConn.(*mongo.Database)
 		dbFriend          = new(models.Friend)
-		friendsCollection = s.db.Collection("friends")
+		friendsCollection = db.Collection("friends")
 		failedResponse    = &proto.Friend{}
 		failedErr         = status.Error(codes.Internal, "Could not et friend request!")
 	)
 
-	if _, err := auth.Authenticate(s.db, req.AuthRequest); err != nil {
+	if _, err := auth.Authenticate(s.Context, req.AuthRequest); err != nil {
 		return nil, err
 	}
 

--- a/services/user/friend_request.go
+++ b/services/user/friend_request.go
@@ -13,19 +13,26 @@ import (
 	"github.com/castyapp/grpc.server/services/auth"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Service) GetPendingFriendRequests(ctx context.Context, req *proto.AuthenticateRequest) (*proto.PendingFriendRequests, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db                = dbConn.(*mongo.Database)
 		friendRequests    = make([]*proto.FriendRequest, 0)
-		userCollection    = s.db.Collection("users")
-		friendsCollection = s.db.Collection("friends")
+		userCollection    = db.Collection("users")
+		friendsCollection = db.Collection("friends")
 	)
 
-	user, err := auth.Authenticate(s.db, req)
+	user, err := auth.Authenticate(s.Context, req)
 	if err != nil {
 		return nil, err
 	}
@@ -69,15 +76,21 @@ func (s *Service) GetPendingFriendRequests(ctx context.Context, req *proto.Authe
 
 func (s *Service) AcceptFriendRequest(ctx context.Context, req *proto.FriendRequest) (*proto.Response, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db                = dbConn.(*mongo.Database)
 		friendRequest     = new(models.Friend)
-		usersCollection   = s.db.Collection("users")
-		friendsCollection = s.db.Collection("friends")
-		notifsCollection  = s.db.Collection("notifications")
+		usersCollection   = db.Collection("users")
+		friendsCollection = db.Collection("friends")
+		notifsCollection  = db.Collection("notifications")
 		failedResponse    = status.Error(codes.Internal, "Could not accept friend request, Please try again later!")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -150,14 +163,14 @@ func (s *Service) AcceptFriendRequest(ctx context.Context, req *proto.FriendRequ
 
 		// sending friend to current user
 		if buffer, err := protocol.NewMsgProtobuf(proto.EMSG_NEW_FRIEND, protoFriend); err == nil {
-			if err := helpers.SendEventToUser(ctx, buffer.Bytes(), protoUser); err != nil {
+			if err := helpers.SendEventToUser(s.Context, buffer.Bytes(), protoUser); err != nil {
 				log.Println(err)
 			}
 		}
 
 		// sending current user to friend
 		if buffer, err := protocol.NewMsgProtobuf(proto.EMSG_NEW_FRIEND, protoUser); err == nil {
-			if err := helpers.SendEventToUser(ctx, buffer.Bytes(), protoFriend); err != nil {
+			if err := helpers.SendEventToUser(s.Context, buffer.Bytes(), protoFriend); err != nil {
 				log.Println(err)
 			}
 		}
@@ -174,15 +187,21 @@ func (s *Service) AcceptFriendRequest(ctx context.Context, req *proto.FriendRequ
 
 func (s *Service) SendFriendRequest(ctx context.Context, req *proto.FriendRequest) (*proto.Response, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
+		db                      = dbConn.(*mongo.Database)
 		friend                  = new(models.User)
-		userCollection          = s.db.Collection("users")
-		friendsCollection       = s.db.Collection("friends")
-		notificationsCollection = s.db.Collection("notifications")
+		userCollection          = db.Collection("users")
+		friendsCollection       = db.Collection("friends")
+		notificationsCollection = db.Collection("notifications")
 		failedResponse          = status.Error(codes.Internal, "Could not create friend request, Please try again later!")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -251,7 +270,7 @@ func (s *Service) SendFriendRequest(ctx context.Context, req *proto.FriendReques
 	// send event to friend clients
 	buffer, err := protocol.NewMsgProtobuf(proto.EMSG_NEW_NOTIFICATION, &proto.NotificationMsgEvent{})
 	if err == nil {
-		if err := helpers.SendEventToUser(ctx, buffer.Bytes(), &proto.User{Id: friend.ID.Hex()}); err != nil {
+		if err := helpers.SendEventToUser(s.Context, buffer.Bytes(), &proto.User{Id: friend.ID.Hex()}); err != nil {
 			log.Println(err)
 		}
 	}

--- a/services/user/friends.go
+++ b/services/user/friends.go
@@ -13,12 +13,12 @@ import (
 
 func (s *Service) GetFriends(ctx context.Context, req *proto.AuthenticateRequest) (*proto.FriendsResponse, error) {
 
-	user, err := auth.Authenticate(s.db, req)
+	user, err := auth.Authenticate(s.Context, req)
 	if err != nil {
 		return nil, err
 	}
 
-	friends, err := helpers.GetFriendsFromDatabase(s.db, ctx, user)
+	friends, err := helpers.GetFriendsFromDatabase(s.Context, user)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, "Could not get friends!")
 	}

--- a/services/user/search.go
+++ b/services/user/search.go
@@ -16,8 +16,14 @@ import (
 
 func (s *Service) Search(ctx context.Context, req *proto.SearchUserRequest) (*proto.SearchUserResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
-		collection    = s.db.Collection("users")
+		db            = dbConn.(*mongo.Database)
+		collection    = db.Collection("users")
 		emptyResponse = &proto.SearchUserResponse{
 			Status: "success",
 			Code:   http.StatusOK,
@@ -25,7 +31,7 @@ func (s *Service) Search(ctx context.Context, req *proto.SearchUserRequest) (*pr
 		}
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/services/user/two_fa.go
+++ b/services/user/two_fa.go
@@ -9,18 +9,25 @@ import (
 	"github.com/castyapp/grpc.server/services"
 	"github.com/castyapp/grpc.server/services/auth"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Service) GenerateRecoveryCodes(ctx context.Context, req *proto.AuthenticateRequest) (*proto.RecoveryCodesResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
-		codesColl      = s.db.Collection("users")
+		db             = dbConn.(*mongo.Database)
+		codesColl      = db.Collection("users")
 		failedResponse = status.Error(codes.Internal, "Could not generate recovery codes, Please try again later!")
 	)
 
-	user, err := auth.Authenticate(s.db, req)
+	user, err := auth.Authenticate(s.Context, req)
 	if err != nil {
 		return nil, err
 	}
@@ -56,10 +63,12 @@ func (s *Service) GenerateRecoveryCodes(ctx context.Context, req *proto.Authenti
 
 func (s *Service) EnableTwoFactorAuth(ctx context.Context, req *proto.TwoFactorAuthRequest) (*proto.Response, error) {
 
+	// TODO: Enable EnableTwoFactorAuth
 	return nil, nil
 }
 
 func (s *Service) DisableTwoFactorAuth(ctx context.Context, req *proto.TwoFactorAuthRequest) (*proto.Response, error) {
 
+	// TODO: Enable DisableTwoFactorAuth
 	return nil, nil
 }

--- a/services/user/update.go
+++ b/services/user/update.go
@@ -11,18 +11,25 @@ import (
 	"github.com/castyapp/grpc.server/helpers"
 	"github.com/castyapp/grpc.server/services/auth"
 	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/mongo"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func (s *Service) UpdateUser(ctx context.Context, req *proto.UpdateUserRequest) (*proto.GetUserResponse, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
-		collection     = s.db.Collection("users")
+		db             = dbConn.(*mongo.Database)
+		collection     = db.Collection("users")
 		failedResponse = status.Error(codes.Internal, "Could not update the user, Please try again later!")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -64,14 +71,14 @@ func (s *Service) UpdateUser(ctx context.Context, req *proto.UpdateUserRequest) 
 		// update self user with new activity to other clients
 		buffer, err := protocol.NewMsgProtobuf(proto.EMSG_SELF_USER_UPDATED, protoUser)
 		if err == nil {
-			if err := helpers.SendEventToUser(ctx, buffer.Bytes(), protoUser); err != nil {
+			if err := helpers.SendEventToUser(s.Context, buffer.Bytes(), protoUser); err != nil {
 				log.Println(err)
 			}
 		}
 
 		// update friends with new activity of user
 		if buffer, err := protocol.NewMsgProtobuf(proto.EMSG_USER_UPDATED, protoUser); err == nil {
-			if err := helpers.SendEventToFriends(s.db, ctx, buffer.Bytes(), user); err != nil {
+			if err := helpers.SendEventToFriends(s.Context, buffer.Bytes(), user); err != nil {
 				return nil, err
 			}
 		}
@@ -89,12 +96,18 @@ func (s *Service) UpdateUser(ctx context.Context, req *proto.UpdateUserRequest) 
 
 func (s *Service) UpdatePassword(ctx context.Context, req *proto.UpdatePasswordRequest) (*proto.Response, error) {
 
+	dbConn, err := s.Get("db.mongo")
+	if err != nil {
+		return nil, err
+	}
+
 	var (
-		collection     = s.db.Collection("users")
+		db             = dbConn.(*mongo.Database)
+		collection     = db.Collection("users")
 		failedResponse = status.Error(codes.Internal, "Could not update the user's password, Please try again later!")
 	)
 
-	user, err := auth.Authenticate(s.db, req.AuthRequest)
+	user, err := auth.Authenticate(s.Context, req.AuthRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/auth_test.go
+++ b/tests/auth_test.go
@@ -1,0 +1,94 @@
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CastyLab/grpc.proto/proto"
+	"github.com/stretchr/testify/assert"
+	"go.mongodb.org/mongo-driver/mongo"
+	"google.golang.org/grpc"
+)
+
+func mockUser() *proto.User {
+	return &proto.User{
+		Fullname: "test-user",
+		Username: "go-test",
+		Password: "random-password",
+		Email:    "random-email@casty.test",
+	}
+}
+
+func dropDatabase(t *testing.T) {
+	db, err := mockConext.Get("db.mongo")
+	assert.NoError(t, err)
+	err = db.(*mongo.Database).Drop(context.TODO())
+	assert.NoError(t, err)
+}
+
+func testGetUser(t *testing.T, name string, client proto.UserServiceClient, user *proto.User, token []byte) {
+	t.Run(name, func(t *testing.T) {
+		userResp, err := client.GetUser(context.TODO(), &proto.AuthenticateRequest{Token: token})
+		assert.NoError(t, err)
+		assert.Equal(t, userResp.Code, int64(200))
+		assert.Equal(t, userResp.Status, "success")
+		assert.Equal(t, userResp.Result.Username, user.Username)
+		assert.Equal(t, userResp.Result.Email, user.Email)
+		assert.Equal(t, userResp.Result.Fullname, user.Fullname)
+	})
+}
+
+func TestAuthentication(t *testing.T) {
+
+	dropDatabase(t)
+	defer dropDatabase(t)
+
+	ctx := context.TODO()
+	conn, err := grpc.DialContext(ctx, "", grpc.WithContextDialer(getBufDialer(grpcListener)), grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("failed to dial: %v", err)
+	}
+
+	mockedUser := mockUser()
+
+	t.Run("RegisterUser", func(t *testing.T) {
+		client := proto.NewUserServiceClient(conn)
+		resp, err := client.CreateUser(ctx, &proto.CreateUserRequest{User: mockedUser})
+		assert.NoError(t, err)
+		assert.Equal(t, resp.Code, int64(200))
+		assert.Equal(t, resp.Status, "success")
+		assert.NotEmpty(t, resp.Token)
+		testGetUser(t, "GetRegisteredUser", client, mockedUser, resp.Token)
+	})
+
+	t.Run("LoginUser", func(t *testing.T) {
+
+		userClient := proto.NewUserServiceClient(conn)
+		authClient := proto.NewAuthServiceClient(conn)
+
+		t.Run("WithUsernameAndPassword", func(t *testing.T) {
+			resp, err := authClient.Authenticate(ctx, &proto.AuthRequest{
+				User: mockedUser.Username,
+				Pass: mockedUser.Password,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, resp.Code, int64(200))
+			assert.Equal(t, resp.Status, "success")
+			assert.NotEmpty(t, resp.Token)
+			testGetUser(t, "GetLoginUser", userClient, mockedUser, resp.Token)
+		})
+
+		t.Run("WithEmailAndPassword", func(t *testing.T) {
+			resp, err := authClient.Authenticate(ctx, &proto.AuthRequest{
+				User: mockedUser.Email,
+				Pass: mockedUser.Password,
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, resp.Code, int64(200))
+			assert.Equal(t, resp.Status, "success")
+			assert.NotEmpty(t, resp.Token)
+			testGetUser(t, "GetLoginUser", userClient, mockedUser, resp.Token)
+		})
+
+	})
+}

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -16,12 +16,12 @@ var defaultConfig = &config.ConfigMap{
 	Redis: config.RedisConfig{
 		Cluster:    false,
 		MasterName: "casty",
-		Addr:       "127.0.0.1:6379",
+		Addr:       "casty.redis:6379",
 		Pass:       "super-secure-redis-password",
 	},
 	DB: config.DBConfig{
 		Name: "casty",
-		Host: "127.0.0.1",
+		Host: "casty.db",
 		Port: 27017,
 		User: "gotest",
 		Pass: "super-secure-mongodb-password",

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -1,54 +1,50 @@
-package config
+package tests
 
 import (
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/castyapp/grpc.server/config"
 )
 
-var defaultConfig = &ConfigMap{
+var defaultConfig = &config.ConfigMap{
 	Debug:    false,
 	Metrics:  false,
 	Env:      "dev",
 	Timezone: "America/California",
-	Listener: GrpcListener{
-		Host: "0.0.0.0",
-		Port: 8000,
+	Redis: config.RedisConfig{
+		Cluster:    false,
+		MasterName: "casty",
+		Addr:       "127.0.0.1:6379",
+		Pass:       "super-secure-redis-password",
 	},
-	Redis: RedisConfig{
-		Cluster:      false,
-		MasterName:   "casty",
-		Sentinels:    []string{"127.0.0.1:26379"},
-		Addr:         "127.0.0.1:26379",
-		Pass:         "super-secure-password",
-		SentinelPass: "super-secure-sentinels-password",
-	},
-	DB: DBConfig{
+	DB: config.DBConfig{
 		Name: "casty",
-		Host: "localhost",
+		Host: "127.0.0.1",
 		Port: 27017,
-		User: "service",
-		Pass: "super-secure-password",
+		User: "gotest",
+		Pass: "super-secure-mongodb-password",
 	},
-	JWT: JWTConfig{
-		AccessToken: JWTToken{
+	JWT: config.JWTConfig{
+		AccessToken: config.JWTToken{
 			Secret: "random-secret",
-			ExpiresAt: JWTExpiresAt{
+			ExpiresAt: config.JWTExpiresAt{
 				Type:  "days",
 				Value: 1,
 			},
 		},
-		RefreshToken: JWTToken{
+		RefreshToken: config.JWTToken{
 			Secret: "random-secret",
-			ExpiresAt: JWTExpiresAt{
+			ExpiresAt: config.JWTExpiresAt{
 				Type:  "days",
 				Value: 7,
 			},
 		},
 	},
-	Oauth: OauthConfig{
+	Oauth: config.OauthConfig{
 		RegistrationByOauth: true,
-		Google: OauthClient{
+		Google: config.OauthClient{
 			Enabled:      false,
 			ClientID:     "",
 			ClientSecret: "",
@@ -56,7 +52,7 @@ var defaultConfig = &ConfigMap{
 			TokenUri:     "https://oauth2.googleapis.com/token",
 			RedirectUri:  "https://casty.ir/oauth/google/callback",
 		},
-		Spotify: OauthClient{
+		Spotify: config.OauthClient{
 			Enabled:      false,
 			ClientID:     "",
 			ClientSecret: "",
@@ -65,16 +61,16 @@ var defaultConfig = &ConfigMap{
 			RedirectUri:  "https://casty.ir/oauth/spotify/callback",
 		},
 	},
-	S3: S3Config{
+	S3: config.S3Config{
 		Endpoint:  "127.0.0.1:9000",
 		AccessKey: "secret-access-key",
 		SecretKey: "secret-key",
 	},
-	Sentry: SentryConfig{
+	Sentry: config.SentryConfig{
 		Enabled: false,
 		Dsn:     "sentry.dsn.here",
 	},
-	Recaptcha: RecaptchaConfig{
+	Recaptcha: config.RecaptchaConfig{
 		Enabled: false,
 		Type:    "hcaptcha",
 		Secret:  "hcaptcha-secret-token",
@@ -82,7 +78,7 @@ var defaultConfig = &ConfigMap{
 }
 
 func TestLoadConfig(t *testing.T) {
-	configMap, err := LoadFile(filepath.Join("config_test.hcl"))
+	configMap, err := config.LoadFile(filepath.Join(configFileName))
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/tests/config_test.hcl
+++ b/tests/config_test.hcl
@@ -17,17 +17,17 @@ redis {
   # If cluster is false, addr is required
   cluster       = false
   master_name   = "casty"
-  addr          = "127.0.0.1:6379"
-  pass          = "super-secure-mongodb-password"
+  addr          = "casty.redis:6379"
+  pass          = "super-secure-redis-password"
 }
 
 # Database (mongodb) config
 db {
   name = "casty"
-  host = "127.0.0.1"
+  host = "casty.db"
   port = 27017
   user = "gotest"
-  pass = "super-secure-redis-password"
+  pass = "super-secure-mongodb-password"
 }
 
 # JWT secrets

--- a/tests/config_test.hcl
+++ b/tests/config_test.hcl
@@ -10,34 +10,24 @@ env = "dev"
 # Timezone
 timezone = "America/California"
 
-# gRPC TCP listener config
-listener {
-  host = "0.0.0.0"
-  port = 8000
-}
-
 # Redis configurations
 redis {
   # if you wish to use redis cluster, set this value to true
   # If cluster is true, sentinels is required
   # If cluster is false, addr is required
-  cluster     = false
-  master_name = "casty"
-  addr        = "127.0.0.1:26379"
-  sentinels   = [
-    "127.0.0.1:26379"
-  ]
-  pass = "super-secure-password"
-  sentinel_pass = "super-secure-sentinels-password"
+  cluster       = false
+  master_name   = "casty"
+  addr          = "127.0.0.1:6379"
+  pass          = "super-secure-mongodb-password"
 }
 
 # Database (mongodb) config
 db {
   name = "casty"
-  host = "localhost"
+  host = "127.0.0.1"
   port = 27017
-  user = "service"
-  pass = "super-secure-password"
+  user = "gotest"
+  pass = "super-secure-redis-password"
 }
 
 # JWT secrets

--- a/tests/init.go
+++ b/tests/init.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/CastyLab/grpc.proto/proto"
+	"github.com/castyapp/grpc.server/config"
+	"github.com/castyapp/grpc.server/core"
+	"github.com/castyapp/grpc.server/db"
+	"github.com/castyapp/grpc.server/jwt"
+	"github.com/castyapp/grpc.server/redis"
+	"github.com/castyapp/grpc.server/services/auth"
+	"github.com/castyapp/grpc.server/services/message"
+	"github.com/castyapp/grpc.server/services/theater"
+	"github.com/castyapp/grpc.server/services/user"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+var (
+	mockConext     *core.Context
+	grpcSrvConn    *grpc.Server
+	grpcListener   *bufconn.Listener
+	configFileName = "./config_test.hcl"
+)
+
+func init() {
+	mockConext = newContext()
+	grpcSrvConn, grpcListener = startGRPCServer()
+}
+
+func newContext() *core.Context {
+
+	ctx := core.NewContext(context.Background())
+	ctx.Set("config.filepath", configFileName)
+
+	return ctx.With(
+
+		// Registering configmap provider
+		config.Provider,
+
+		// config database (mongodb)
+		db.Provider,
+
+		// configure jwt
+		func(ctx *core.Context) error {
+			cm := ctx.MustGet("config.map").(*config.ConfigMap)
+			if err := jwt.Load(cm); err != nil {
+				return fmt.Errorf("could not load jwt configuration: %v", err)
+			}
+			return nil
+		},
+
+		// configure redis connection
+		redis.Provider,
+	)
+}
+
+func getBufDialer(listener *bufconn.Listener) func(context.Context, string) (net.Conn, error) {
+	return func(ctx context.Context, url string) (net.Conn, error) {
+		return listener.Dial()
+	}
+}
+
+func startGRPCServer() (*grpc.Server, *bufconn.Listener) {
+
+	bufferSize := 1024 * 1024
+	listener := bufconn.Listen(bufferSize)
+	server := grpc.NewServer()
+
+	proto.RegisterAuthServiceServer(server, auth.NewService(mockConext))
+	proto.RegisterUserServiceServer(server, user.NewService(mockConext))
+	proto.RegisterTheaterServiceServer(server, theater.NewService(mockConext))
+	proto.RegisterMessagesServiceServer(server, message.NewService(mockConext))
+
+	go func() {
+		if err := server.Serve(listener); err != nil {
+			log.Fatalf("failed to start grpc server: %v", err)
+		}
+	}()
+
+	return server, listener
+}


### PR DESCRIPTION
Redesigning config from yaml to hcl
Renaming project path from CastyLab/grpc.server to castyapp/grpc.server
Removing db.Connection which was a mongodb connection and moved it into services instaces as a field internally
Adding core.Context concept to use ctx.Get for getting redis/config or mongodb connection in services
Adding unit tests
Adding docker-test github action
Adding redis and mongodb container to run on docker-test.yaml github action
Introducing providers instead of a function for registering clients
We use Register and Close functions inside provider for registering and closing a client
